### PR TITLE
Ignore curs_set(0) error

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -16,7 +16,13 @@ class CursedMenu(object):
         curses.noecho()
         curses.raw()
         curses.start_color()
-        curses.curs_set(0)
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            # Not all terminals support this functionality.
+            # When the error is ignored the screen will look a little uglier, but that's not terrible
+            # So in order to keep botany as accesible as possible to everyone, it should be safe to ignore the error.
+            pass
         self.screen.keypad(1)
         self.plant = this_plant
         self.user_data = this_data


### PR DESCRIPTION
~sui has mentioned that botany always crashes for him with the stack trace:  
    Traceback (most recent call last):   File "/home/curiouser/botany/botany.py", line 543, in <module>     botany_menu == CursedMenu(my_plant,my_data)   File "/home/curiouser/botany/menu_screen.py", line 19, in __init__     curses.curs_set(0) _curses.error: curs_set() returned ERR

According to the docs, an error will be returned when the terminal does not support the visibility requested.
Appearently hiding the cursor is not supported in ~sui's terminal (cmder).

To keep botany as accesible as possible I suggest to ignore this error.