### PR TITLE
don't try to use colours if unsupported; fix #7

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -18,7 +18,8 @@ class CursedMenu(object):
         self.screen = curses.initscr()
         curses.noecho()
         curses.raw()
-        curses.start_color()
+        if curses.has_colors():
+            curses.start_color()
         try:
             curses.curs_set(0)
         except curses.error:
@@ -35,8 +36,11 @@ class CursedMenu(object):
         self.infotoggle = 0
         self.maxy, self.maxx = self.screen.getmaxyx()
         # Highlighted and Normal line definitions
-        self.define_colors()
-        self.highlighted = curses.color_pair(1)
+        if curses.has_colors():
+            self.define_colors()
+            self.highlighted = curses.color_pair(1)
+        else:
+            self.highlighted = curses.A_REVERSE
         self.normal = curses.A_NORMAL
         # Threaded screen update for live changes
         screen_thread = threading.Thread(target=self.update_plant_live, args=())


### PR DESCRIPTION
Only use colours when the terminal supports them.
The same highlighting can be used with `curses.A_REVERSE`. I think `curses.A_STANDOUT` could work as well