### PR TITLE
properly clean up after crash

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -622,7 +622,10 @@ if __name__ == '__main__':
     # my_plant is either a fresh plant or an existing plant at this point
     my_plant.start_life()
     my_data.start_threads(my_plant)
-    botany_menu = CursedMenu(my_plant,my_data)
-    my_data.save_plant(my_plant)
-    my_data.data_write_json(my_plant)
-    my_data.update_garden_db(my_plant)
+    try:
+        botany_menu = CursedMenu(my_plant,my_data)
+        my_data.save_plant(my_plant)
+        my_data.data_write_json(my_plant)
+        my_data.update_garden_db(my_plant)
+    finally:
+        cleanup()

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -670,7 +670,14 @@ class CursedMenu(object):
 
     def __exit__(self):
         self.exit = True
+        cleanup()
+
+def cleanup():
+    try:
         curses.curs_set(2)
-        curses.endwin()
-        os.system('clear')
+    except curses.error:
+        # cursor not supported; just ignore
+        pass
+    curses.endwin()
+    os.system('clear')
 


### PR DESCRIPTION
put cleanup in finally block so it happens no matter the crash
this should prevend scrambled lines all over the terminal