### PR TITLE
Add controls for the garden screen

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -284,7 +284,7 @@ class CursedMenu(object):
                     entry = "{:14} - {:>16} - {:>8}p - {}\n".format(
                         this_plant["owner"],
                         this_plant["age"],
-                        this_plant["score"],
+                        int(this_plant["score"]),
                         this_plant["description"]
                     )
                     plant_table += entry
@@ -505,6 +505,8 @@ class CursedMenu(object):
             info_text = info_text.splitlines()
         for y, line in enumerate(info_text, 2):
             this_y = y+12 + y_offset
+            if len(line) > self.maxx - 3:
+                line = line[:self.maxx-3]
             if this_y < self.maxy:
                 self.screen.addstr(this_y, 2, line, curses.A_NORMAL)
         self.screen.refresh()


### PR DESCRIPTION
This PR adds some control to the garden screen:

- ESC, q, x: quit
- SPC, RET, PGDOWN: next page. If used at the last page, quits.
- BACKSPACE, PGUP: previous page
- j, DOWN: next line
- k, UP: previous line
- s: sort list, then alternate between ascending and descending order. The column used to sort is determined by the next key:
  - n, 1: name
  - a, 2: age
  - s, 3: score
  - d, 4: description
- f, /: filter/search items. This prompts for a regex and keeps lines containing the regex. If the regex is invalid, nothing is matched.

It also:

- fixes a few display bugs (prevents long lines from overflowing and integer score in the garden)
- generalizes the `get_user_string` function (can now be used for a dynamic character set instead of just alphanumeric) and fixes its redraw (used a static offset before)