### PR TITLE
Limit length of longer usernames

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -308,7 +308,7 @@ class CursedMenu(object):
         return plant_table
 
     def format_garden_entry(self, entry):
-        return "{:14} - {:>16} - {:>8}p - {}".format(*entry)
+        return "{:14.14} - {:>16} - {:>8}p - {}".format(*entry)
 
     def sort_garden_table(self, table, column, ascending):
         """ Sort table in place by a specified column """

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -301,7 +301,7 @@ class CursedMenu(object):
             if this_garden[plant_id]:
                 if not this_garden[plant_id]["dead"]:
                     this_plant = this_garden[plant_id]
-                    plant_table.append((this_plant["owner"][:14],
+                    plant_table.append((this_plant["owner"],
                                         this_plant["age"],
                                         int(this_plant["score"]),
                                         this_plant["description"]))

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -301,7 +301,7 @@ class CursedMenu(object):
             if this_garden[plant_id]:
                 if not this_garden[plant_id]["dead"]:
                     this_plant = this_garden[plant_id]
-                    plant_table.append((this_plant["owner"],
+                    plant_table.append((this_plant["owner"][:14],
                                         this_plant["age"],
                                         int(this_plant["score"]),
                                         this_plant["description"]))


### PR DESCRIPTION
# Why?

 * Long usernames cause the garden menu to shift over.

![botany_screenshot](https://user-images.githubusercontent.com/1388608/48815836-71859780-ed05-11e8-827e-9c301d00e82c.png)

# What's New?

 * Change `menu_screen.py` to truncate long usernames to a max length of `75`.

I don't work with Python or Curses much. If I'm violating a style guide or something please let me know.
