### PR TITLE
changed shebang to increase portability @ahriman/tilde.town

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import division
 import time


### PR DESCRIPTION
This is a change I had to make to run botany on ~institute. The change is minor and allows botany to run regardless of where python2 is installed on a system, by relying on /usr/bin/env rather than the python2 path.