### PR TITLE
Added info about where the readme actually is

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -581,6 +581,7 @@ class CursedMenu(object):
                                 "growing. 5 days without water = death. your\n"
                                 "plant depends on you & your friends to live!\n"
                                 "more info is available in the readme :)\n"
+                                "https://github.com/jifunks/botany/blob/master/README.md\n"
                                 "                               cheers,\n"
                                 "                               curio\n"
                                 )


### PR DESCRIPTION
The help menu points out to the readme for more info, but, in cases
where people are using this because it is installed on their server, but
they weren't the ones getting it from the web, they probably don't know
where to find that README. It might not happen to many people, but it
happened to me :-)

This patch just adds another line, with the URL for the README.