### PR TITLE
Don't let evil visitors kill a plant by adding old timestamps

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -237,7 +237,7 @@ class Plant(object):
                         if element['user'] not in visitors_this_check:
                             visitors_this_check.append(element['user'])
                         # prevent users from manually setting watered_time in the future
-                        if element['timestamp'] <= int(time.time()):
+                        if element['timestamp'] <= int(time.time() and element['timestamp'] >= self.watered_timestamp):
                             guest_timestamps.append(element['timestamp'])
                     try:
                        self.update_visitor_db(visitors_this_check)


### PR DESCRIPTION
As described in #33 it is possible to kill someone else's plant even if they watered it every day by adding a very old timestamp in visitors.json.

This fixes #33 by ignoring all timestamps that are older than the last time the user themself watered their plant.

It is still possible to crash someone elses viewer by making the structure of their visitors.json incorrect, but at least that will be noticable and reversible.