### PR TITLE
don't use "is" to compare string literals

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -89,7 +89,7 @@ class CursedMenu(object):
 
     def set_options(self, options):
         # Validates that the last option is "exit"
-        if options[-1] is not 'exit':
+        if options[-1] != 'exit':
             options.append('exit')
         self.options = options
 
@@ -114,7 +114,7 @@ class CursedMenu(object):
         # Actually draws the menu and handles branching
         request = ""
         try:
-            while request is not "exit":
+            while request != "exit":
                 self.draw()
                 request = self.get_user_input()
                 self.handle_request(request)


### PR DESCRIPTION
The is operator checks if the objects are the same (that is, if id(x) == id(y)). While this might work for small numbers and, I guess, small strings, it could fail just as well. AFAIK, the only literals it should be used with are None, True and False.
This fixes a SyntaxWarning in Python 3.8.6 too.