### PR TITLE
Stop making all plants godly

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -174,10 +174,10 @@ class Plant(object):
         # Generate plant rarity
         CONST_RARITY_MAX = 256.0
         rare_seed = random.randint(1,CONST_RARITY_MAX)
-        common_range =    round((2/3)*CONST_RARITY_MAX)
-        uncommon_range =  round((2/3)*(CONST_RARITY_MAX-common_range))
-        rare_range =      round((2/3)*(CONST_RARITY_MAX-common_range-uncommon_range))
-        legendary_range = round((2/3)*(CONST_RARITY_MAX-common_range-uncommon_range-rare_range))
+        common_range =    round((2.0/3)*CONST_RARITY_MAX)
+        uncommon_range =  round((2.0/3)*(CONST_RARITY_MAX-common_range))
+        rare_range =      round((2.0/3)*(CONST_RARITY_MAX-common_range-uncommon_range))
+        legendary_range = round((2.0/3)*(CONST_RARITY_MAX-common_range-uncommon_range-rare_range))
 
         common_max = common_range
         uncommon_max = common_max + uncommon_range


### PR DESCRIPTION
Almost all plants seem to get godly rarity (see https://tilde.town/~lucidiot/botany.html and https://tilde.town/~troido/hortus.txt).

python2 division of integers always results in an integer, so `(2/3)` would result in `0`.
This caused all plants to get "godly" as rarity.
This change makes sure a float division is being used.

I don't have an explanation for why there are plants that are not godly (except if they were planted in an older version of botany)