### PR TITLE
save_plant: inelegant concurrency fix

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -561,7 +561,7 @@ class DataManager(object):
     def save_plant(self, this_plant):
         # create savefile
         this_plant.last_time = int(time.time())
-        temp_path = self.savefile_path + ".temp"
+        temp_path = self.savefile_path + ".temp" + str(random.randint(0,1000))
         with open(temp_path, 'wb') as f:
             pickle.dump(this_plant, f, protocol=2)
         os.rename(temp_path, self.savefile_path)


### PR DESCRIPTION
This inelegant and hackyish fix gives a randomly generated name to the
temporary savefiles, so there is only a 0.1% chance of the filename
being the same twice in a row.

This solves the ocasional exceptions raised in save_plant, when there
is more than one call still running at once, for the same user (due to
slow writes).