### PR TITLE
On harvest confirmation message, default to Y when user presses enter

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -508,8 +508,6 @@ class DataManager(object):
 
     def update_garden_db(self, this_plant):
         # insert or update this plant id's entry in DB
-        # TODO: make sure other instances of user are deleted
-        #   Could create a clean db function
         self.init_database()
         self.migrate_database()
         age_formatted = self.plant_age_convert(this_plant)
@@ -528,6 +526,13 @@ class DataManager(object):
                             psco = str(this_plant.ticks),
                             pdead = int(this_plant.dead))
         c.execute(update_query)
+        # clean other instances of user
+        clean_query = """UPDATE garden set is_dead = 1
+                   where owner = '{pown}'
+                   and plant_id <> '{pid}'
+                   """.format(pown = this_plant.owner,
+                              pid = this_plant.plant_id)
+        c.execute(clean_query)
         conn.commit()
         conn.close()
 

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -633,7 +633,7 @@ class CursedMenu(object):
         if user_in == -1: # Input comes from pipe/file and is closed
             raise IOError
 
-        if user_in in [ord('Y'), ord('y')]:
+        if user_in in [ord('Y'), ord('y'), 10]:
             self.plant.start_over()
         else:
             pass


### PR DESCRIPTION
When user selects harvest action, the confirmation message says:

```
If you harvest your plant you'll start over from a seed.
Continue? (Y/n)
````

The fact that the option 'Y' is in caps, suggests that it is the default option. So, when user only presses enter, it should be the same as pressing Y.