### PR TITLE
Support Python 3.12

### DIFF
--- a/plant.py
+++ b/plant.py
@@ -164,7 +164,7 @@ class Plant:
     def rarity_check(self):
         # Generate plant rarity
         CONST_RARITY_MAX = 256.0
-        rare_seed = random.randint(1,CONST_RARITY_MAX)
+        rare_seed = random.randint(1,int(CONST_RARITY_MAX))
         common_range =    round((2.0/3)*CONST_RARITY_MAX)
         uncommon_range =  round((2.0/3)*(CONST_RARITY_MAX-common_range))
         rare_range =      round((2.0/3)*(CONST_RARITY_MAX-common_range-uncommon_range))


### PR DESCRIPTION
Python 3.12 no longer supports using non-integer values as arguments for certain random functions (see [Changes in the Python API for 3.12][0]). This PR casts `CONST_RARITY_MAX` to an integer to prevent a `TypeError` from being raised.

[0]: https://docs.python.org/3/whatsnew/3.12.html#changes-in-the-python-api