### PR TITLE
Round growth rate to single decimal

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -564,7 +564,7 @@ class CursedMenu(object):
             # get plant description before printing
             output_string = self.get_plant_description(this_plant)
             growth_multiplier = 1 + (0.2 * (this_plant.generation-1))
-            output_string += "Generation: {}\nGrowth rate: {}x".format(self.plant.generation, growth_multiplier)
+            output_string += "Generation: {}\nGrowth rate: {:.1f}x".format(self.plant.generation, growth_multiplier)
             self.draw_info_text(output_string)
             self.infotoggle = 1
         else:


### PR DESCRIPTION
At generation 8, the growth rate in the "look" message is displayed as:

> 2.4000000000000004x

To make it display "2.4x" instead, I used the [format specification][0] to display growth rate with only a single decimal place.

[0]: https://docs.python.org/3/library/string.html#format-specification-mini-language