### PR TITLE
Fix missing datetime import

### DIFF
--- a/botany-view.py
+++ b/botany-view.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+import datetime
+
 from botany import *
 
 def ascii_render(filename):
@@ -9,7 +12,7 @@ def ascii_render(filename):
     this_string = this_file.read()
     this_file.close()
     print(this_string)
- 
+
 def draw_plant_ascii(this_plant):
     # this list should be somewhere where it could have been inherited, instead
     # of hardcoded in more than one place...


### PR DESCRIPTION
`python botany-view.py` was failing to launch because it tried to use the `datetime` module without importing it. This minimally fixes that.

I like the idea of `botany-view.py`, and it seems like there's ways that we could give it more love beyond this fix. For example, you could imagine able to invoke it with a command like `botany --non-interactive` instead of as a separate script, for discoverability. And there's a comment here pointing out some duplication around the `plant_art_list` variable; we could resolve that. Are you open to more contributions in this direction?