### PR TITLE
Improve state and error handling in Python 3.13

### DIFF
--- a/botany.py
+++ b/botany.py
@@ -297,10 +297,7 @@ if __name__ == '__main__':
     # my_plant is either a fresh plant or an existing plant at this point
     my_plant.start_life(my_data)
 
-    try:
-        botany_menu = ms.CursedMenu(my_plant,my_data)
-        my_data.save_plant(my_plant)
-        my_data.data_write_json(my_plant)
-        my_data.update_garden_db(my_plant)
-    finally:
-        ms.cleanup()
+    ms.main(my_plant, my_data)
+    my_data.save_plant(my_plant)
+    my_data.data_write_json(my_plant)
+    my_data.update_garden_db(my_plant)

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -244,7 +244,7 @@ class CursedMenu(object):
         # gets the user's input
         user_in = self.screen.getch() # Gets user input
         if user_in == -1: # Input comes from pipe/file and is closed
-            raise IOError
+            raise OSError("Failed to read from input")
         ## DEBUG KEYS - enable these lines to see curses key codes
         # self.screen.addstr(2, 2, str(user_in), curses.A_NORMAL)
         # self.screen.refresh()
@@ -363,7 +363,7 @@ class CursedMenu(object):
             self.screen_lock.release()
             c = self.screen.getch()
             if c == -1: # Input comes from pipe/file and is closed
-                raise IOError
+                raise OSError("Failed to read from input")
             self.infotoggle = 0
 
             # Quit
@@ -387,7 +387,7 @@ class CursedMenu(object):
             elif c == ord("s"):
                 c = self.screen.getch()
                 if c == -1: # Input comes from pipe/file and is closed
-                    raise IOError
+                    raise OSError("Failed to read from input")
                 column = -1
                 if c < 255 and chr(c) in sort_keys:
                     column = sort_keys.index(chr(c))
@@ -616,7 +616,7 @@ class CursedMenu(object):
         self.draw_info_text(harvest_text)
         user_in = self.screen.getch() # Gets user input
         if user_in == -1: # Input comes from pipe/file and is closed
-            raise IOError
+            raise OSError("Failed to read from input")
 
         if user_in in [ord('Y'), ord('y'), 10]:
             self.plant.start_over()
@@ -678,7 +678,7 @@ class CursedMenu(object):
         while user_input != 10:
             user_input = self.screen.getch()
             if user_input == -1: # Input comes from pipe/file and is closed
-                raise IOError
+                raise OSError("Failed to read from input")
             self.screen_lock.acquire()
             # osx and unix backspace chars...
             if user_input == 127 or user_input == 263:

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -23,14 +23,15 @@ if TYPE_CHECKING:
 class CursedMenu(object):
     #TODO: name your plant
     '''A class which abstracts the horrors of building a curses-based menu system'''
-    def __init__(self, this_plant, this_data):
+    def __init__(
+        self,
+        stdscr: curses.window,
+        this_plant: Plant,
+        this_data: "DataManager",
+    ):
         '''Initialization'''
         self.initialized = False
-        self.screen = curses.initscr()
-        curses.noecho()
-        curses.raw()
-        if curses.has_colors():
-            curses.start_color()
+        self.screen = stdscr
         try:
             curses.curs_set(0)
         except curses.error:
@@ -61,7 +62,6 @@ class CursedMenu(object):
         # Recursive lock to prevent both threads from drawing at the same time
         self.screen_lock = threading.RLock()
         self.screen.clear()
-        self.show(["water","look","garden","visit", "instructions"], title=' botany ', subtitle='options')
 
     def define_colors(self):
         # TODO: implement colors
@@ -857,3 +857,15 @@ def cleanup():
     curses.endwin()
     os.system('clear')
 
+
+def menu(stdscrn: curses.window, *, this_plant, this_data):
+    menu = CursedMenu(stdscrn, this_plant=this_plant, this_data=this_data)
+    menu.show(
+        ["water", "look", "garden", "visit", "instructions"],
+        title=" botany ",
+        subtitle="options",
+    )
+
+
+def main(this_plant: Plant, this_data: "DataManager"):
+    return curses.wrapper(menu, this_plant=this_plant, this_data=this_data)

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -1,17 +1,24 @@
 import curses
-import math
-import os
-import traceback
-import threading
-import time
-import random
+import datetime
 import getpass
 import json
+import math
+import os
+import random
+import re
 import sqlite3
 import string
-import re
+import threading
+import time
+import traceback
+from typing import TYPE_CHECKING
+
 import completer
-import datetime
+from plant import Plant
+
+if TYPE_CHECKING:
+    from botany import DataManager
+
 
 class CursedMenu(object):
     #TODO: name your plant


### PR DESCRIPTION
This PR refactors the error handling in the `menu_screen` module to rely on [`curses.wrapper`](https://docs.python.org/3.13/library/curses.html#curses.wrapper) to log errors and cleanup the terminal state, rather than a custom `cleanup` function.

Fixes this issue that appears when quitting the program on Python 3.13:

```
Traceback (most recent call last):
  File "/home/noelle/dev/botany/botany.py", line 306, in <module>
    ms.cleanup()
    ~~~~~~~~~~^^
  File "/home/noelle/dev/botany/menu_screen.py", line 850, in cleanup
    curses.endwin()
    ~~~~~~~~~~~~~^^
_curses.error: endwin() returned ERR
```

In addition to better error handling, `curses.wrapper` also sets up [`cbreak` mode](https://docs.python.org/3.13/library/curses.html#curses.cbreak) and [initializes basic colors](https://docs.python.org/3.13/library/curses.html#curses.start_color). Now pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> will exit the program immediately as expected.

Some exception handling has been narrowed to specific exceptions, and `IOError` instances have been replaced by `OSError` ([PEP 3151](https://peps.python.org/pep-3151/)).

The `CursedMenu.screen_lock` [reentrant lock](https://docs.python.org/3.13/library/threading.html#threading.RLock) is now used as a context manager to automatically release the lock when finished.

`CursedMenu.handle_request` has been rewritten using a [match statement](https://docs.python.org/3.13/reference/compound_stmts.html#the-match-statement) for clarity.