### PR TITLE
fix flicker by calling clear_plant_ascii() less often

### DIFF
--- a/menu_screen.py
+++ b/menu_screen.py
@@ -47,6 +47,7 @@ class CursedMenu(object):
         self.screen.keypad(1)
         self.plant = this_plant
         self.visited_plant = None
+        self.rendered_art = None
         self.user_data = this_data
         self.plant_string = self.plant.parse_plant()
         if self.debug_art:
@@ -223,6 +224,9 @@ class CursedMenu(object):
         return True
 
     def art_render(self, filename, ypos, xpos):
+        if self.rendered_art != filename: # check to prevent flicker
+            self.clear_plant_ascii(ypos, xpos)
+        self.rendered_art = filename # update onscreen art
         if self.debug_art:
             if self.debug_filename.endswith('.ansi') and self.use_color():
                 self.ansi_render(self.debug_filename.split('.')[0], ypos, xpos)
@@ -248,7 +252,6 @@ class CursedMenu(object):
     def draw_plant_ascii(self, this_plant):
         ypos = 0
         xpos = int((self.maxx-37)/2 + 25)
-        self.clear_plant_ascii(ypos, xpos)
         plant_art_list = [
             'poppy',
             'cactus',


### PR DESCRIPTION
Tested on tilde.town with a copy of botany in my homedir (not quite the same, garden doesn't have anyone else in it, but visiting works). Video attached.

With fix, no flicker:

https://github.com/user-attachments/assets/75e67bb5-5b49-4ae3-8e5f-ba896b8d8287

Without fix, before (note how the plant art flickers):


https://github.com/user-attachments/assets/70b04d0b-2720-401e-87d9-48ca9f2b977b

